### PR TITLE
lib: rewrite and split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,13 +113,11 @@ dependencies = [
  "httparse",
  "jni",
  "libc",
- "log",
  "log-panics",
  "openssl-sys",
  "ring",
  "rusqlite",
  "serde 1.0.125",
- "simple-logging",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -119,6 +126,8 @@ dependencies = [
  "tor-dirmgr",
  "tor-proto",
  "tor-rtcompat",
+ "tracing",
+ "tracing-fmt",
  "url",
  "webpki-roots",
 ]
@@ -1199,10 +1208,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -1327,7 +1351,7 @@ dependencies = [
  "num-iter",
  "num-traits 0.2.14",
  "rand 0.8.3",
- "smallvec",
+ "smallvec 1.6.1",
  "zeroize",
 ]
 
@@ -1437,6 +1461,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "owning_ref"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1462,8 +1495,8 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall 0.2.7",
- "smallvec",
+ "redox_syscall",
+ "smallvec 1.6.1",
  "winapi",
 ]
 
@@ -1723,12 +1756,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85dd92e586f7355c633911e11f77f3d12f04b1b1bd76a198bd34ae3af8341ef2"
@@ -1743,7 +1770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.2",
- "redox_syscall 0.2.7",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1754,6 +1781,15 @@ checksum = "ce5f1ceb7f74abbce32601642fcf8e8508a8a8991e0621c7d750295b9095702b"
 dependencies = [
  "aho-corasick",
  "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
  "regex-syntax",
 ]
 
@@ -1820,7 +1856,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "memchr",
- "smallvec",
+ "smallvec 1.6.1",
 ]
 
 [[package]]
@@ -2045,17 +2081,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 
 [[package]]
-name = "simple-logging"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00d48e85675326bb182a2286ea7c1a0b264333ae10f27a937a72be08628b542"
-dependencies = [
- "lazy_static",
- "log",
- "thread-id",
-]
-
-[[package]]
 name = "simple_asn1"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,6 +2106,15 @@ checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
+dependencies = [
+ "maybe-uninit",
+]
+
+[[package]]
+name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
@@ -2100,6 +2134,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -2145,7 +2185,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rand 0.8.3",
- "redox_syscall 0.2.7",
+ "redox_syscall",
  "remove_dir_all",
  "winapi",
 ]
@@ -2177,17 +2217,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread-id"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
-dependencies = [
- "libc",
- "redox_syscall 0.1.57",
- "winapi",
 ]
 
 [[package]]
@@ -2638,6 +2667,75 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-util",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-fmt"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "880547feb88739526e322a366be2411c41c797f0dabcddfe99a3216e5a664f71"
+dependencies = [
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192ca16595cdd0661ce319e8eede9c975f227cdaabc4faaefdc256f43d852e45"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "owning_ref",
+ "regex",
+ "smallvec 0.6.14",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,8 @@ dependencies = [
  "core-foundation 0.6.4",
  "env_logger 0.6.2",
  "futures",
+ "http",
+ "httparse",
  "jni",
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "ring",
  "rusqlite",
  "serde 1.0.125",
+ "tempdir",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -784,6 +785,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -1665,6 +1672,19 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -1711,6 +1731,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -1752,6 +1787,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2174,6 +2218,16 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ core-foundation = "0.6.2"
 [build-dependencies]
 env_logger = "0.6"
 
+[dev-dependencies]
+tempdir = "0.3"
+
 [profile.release]
 lto = "fat"
 opt-level = "s"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ serde = { version = "1.0.124", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tokio-util = { version = "0.6.7", features = ["full"] }
 futures = "0.3"
+http = "0.2"
+httparse = "1"
 config = "0.11.0"
 simple-logging = "2.0.2"
 anyhow = "1.0.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,10 @@ name = "core"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-log = "0.4.6"
 log-panics = "2.0"
+# TODO features = "log" might be needed by android
+tracing = "0.1"
+tracing-fmt = "0.1"
 
 # Packages for tor
 tor-client = { git = "https://gitlab.torproject.org/tpo/core/arti.git", rev = "c372671b5ad2663151cbaf2ff392f1e6f0ba292f" }
@@ -29,7 +31,6 @@ futures = "0.3"
 http = "0.2"
 httparse = "1"
 config = "0.11.0"
-simple-logging = "2.0.2"
 anyhow = "1.0.40"
 tokio-rustls = "0.22"
 webpki-roots = "0.21"

--- a/src/arti.rs
+++ b/src/arti.rs
@@ -170,6 +170,8 @@ impl ArtiConfig {
 
 #[cfg(test)]
 mod tests {
+    use tempdir::TempDir;
+
     use crate::tests;
 
     use super::*;
@@ -178,11 +180,13 @@ mod tests {
     fn clearnet_and_tor_gives_the_same_page() {
         tests::setup_tracing();
 
+        let tempdir = TempDir::new("tor-cache").expect("create temp dir");
+
         tls_send(
             "www.c4dt.org",
             "GET /index.html HTTP/1.0\nHost: www.c4dt.org\n\n",
             &DirectoryCache {
-                tmp_dir: Some("/tmp/tor-cache".into()),
+                tmp_dir: tempdir.path().to_str().map(String::from),
                 nodes: None,
                 relays: None,
             },

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,8 @@
 use std::io::Write;
 
 use anyhow::{bail, Context, Result};
-use log::trace;
-
 use http::{Request, Response};
+use tracing::trace;
 
 use super::{arti::tls_send, DirectoryCache};
 
@@ -101,10 +100,8 @@ mod tests {
 
     #[test]
     fn test_get() {
-        simple_logging::log_to(std::io::stdout(), log::LevelFilter::Debug);
-
         let resp = Client::new(DirectoryCache {
-            tmp_dir: None,
+            tmp_dir: Some("/tmp/tor-cache/test_get".into()),
             nodes: None,
             relays: None,
         })

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,121 @@
+use std::io::Write;
+
+use anyhow::{bail, Context, Result};
+use log::trace;
+
+use http::{Request, Response};
+
+use super::{arti::tls_send, DirectoryCache};
+
+pub struct Client {
+    dir_cache: DirectoryCache,
+}
+
+impl Client {
+    pub fn new(dir_cache: DirectoryCache) -> Self {
+        Self { dir_cache }
+    }
+
+    /// Sends the request to the given URL. It returns the response.
+    pub fn send(&self, req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>> {
+        trace!("request: {:?}", req);
+
+        let uri = req.uri().clone();
+        let host = uri.host().context("no host found")?;
+
+        let raw_req = serialize_request(req).context("serialize request")?;
+
+        let raw_resp = tls_send(
+            host,
+            &String::from_utf8(raw_req).context("encode serialized as utf-8")?,
+            &self.dir_cache,
+        )?
+        .into_bytes();
+
+        let resp = deserialize_response(raw_resp);
+
+        trace!("response: {:?}", resp);
+
+        resp
+    }
+}
+
+fn serialize_request(req: Request<Vec<u8>>) -> Result<Vec<u8>> {
+    let (parts, mut body) = req.into_parts();
+
+    let mut ret = Vec::new();
+
+    write!(
+        &mut ret,
+        "{} {} {:?}\r\n",
+        parts.method, parts.uri, parts.version,
+    )
+    .context("write status line")?;
+
+    for (key, value) in parts.headers {
+        write!(
+            &mut ret,
+            "{}: {}\r\n",
+            key.context("missing header name")?,
+            value.to_str().context("serialize header value as string")?,
+        )
+        .context("write header")?;
+    }
+
+    write!(&mut ret, "\r\n").context("write last EOL")?;
+
+    ret.append(&mut body);
+
+    Ok(ret)
+}
+
+fn deserialize_response(mut raw_resp: Vec<u8>) -> Result<Response<Vec<u8>>> {
+    const MAX_HEADERS: usize = 16;
+
+    let mut headers = [httparse::EMPTY_HEADER; MAX_HEADERS];
+
+    let mut http_resp = httparse::Response::new(&mut headers);
+    let parsed = http_resp.parse(raw_resp.as_slice())?;
+    if parsed.is_partial() {
+        bail!("unfinished response");
+    }
+
+    let mut builder = Response::builder()
+        .status(http_resp.code.context("no status")?)
+        .version(if http_resp.version.context("no version")? == 0 {
+            http::Version::HTTP_10
+        } else {
+            http::Version::HTTP_11
+        });
+    for header in http_resp.headers {
+        builder = builder.header(header.name, header.value)
+    }
+    builder
+        .body(raw_resp.split_off(parsed.unwrap()))
+        .context("create response")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get() {
+        simple_logging::log_to(std::io::stdout(), log::LevelFilter::Debug);
+
+        let resp = Client::new(DirectoryCache {
+            tmp_dir: None,
+            nodes: None,
+            relays: None,
+        })
+        .send(
+            Request::get("https://www.c4dt.org")
+                .header("Host", "www.c4dt.org")
+                .body(vec![])
+                .expect("create get request"),
+        )
+        .expect("send request");
+
+        assert_eq!(resp.status(), 200);
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Context, Result};
 use http::{Request, Response};
 use tracing::trace;
 
-use super::{arti::tls_send, DirectoryCache};
+use crate::{arti::tls_send, DirectoryCache};
 
 pub struct Client {
     dir_cache: DirectoryCache,
@@ -96,12 +96,15 @@ fn deserialize_response(mut raw_resp: Vec<u8>) -> Result<Response<Vec<u8>>> {
 
 #[cfg(test)]
 mod tests {
+    use tempdir::TempDir;
+
     use super::*;
 
     #[test]
     fn test_get() {
+        let tempdir = TempDir::new("tor-cache").expect("create temp dir");
         let resp = Client::new(DirectoryCache {
-            tmp_dir: Some("/tmp/tor-cache/test_get".into()),
+            tmp_dir: tempdir.path().to_str().map(String::from),
             nodes: None,
             relays: None,
         })

--- a/src/ffi/android.rs
+++ b/src/ffi/android.rs
@@ -1,10 +1,10 @@
-use jni::JNIEnv;
 use jni::objects::{JClass, JString};
 use jni::sys::jstring;
+use jni::JNIEnv;
 use log::info;
 
-use crate::{Request, DirectoryCache};
-
+use crate::{client::Client, DirectoryCache};
+use http::Request;
 
 const ANDROID_LOG_TAG: &str = "ArtiLib";
 
@@ -14,20 +14,20 @@ pub unsafe extern "system" fn Java_org_c4dt_artiwrapper_JniApi_hello(
     _: JClass,
     who: JString,
 ) -> jstring {
-    let str: String = env.get_string(who)
-        .expect("Couldn't create rust string").into();
+    let str: String = env
+        .get_string(who)
+        .expect("Couldn't create rust string")
+        .into();
 
-    let output = env.new_string(format!("Hello {}!", str))
+    let output = env
+        .new_string(format!("Hello {}!", str))
         .expect("Couldn't create java string");
 
     output.into_inner()
 }
 
 #[no_mangle]
-pub unsafe extern "system" fn Java_org_c4dt_artiwrapper_JniApi_initLogger(
-    _: JNIEnv,
-    _: JClass,
-) {
+pub unsafe extern "system" fn Java_org_c4dt_artiwrapper_JniApi_initLogger(_: JNIEnv, _: JClass) {
     // Important: Logcat doesn't contain stdout / stderr so we need a custom logger.
     // An alternative solution to android_logger, is to register a callback
     // (Using the same functionality as registerCallback) to send the logs.
@@ -50,21 +50,35 @@ pub unsafe extern "system" fn Java_org_c4dt_artiwrapper_JniApi_tlsGet(
     cache_dir_j: JString,
     domain_j: JString,
 ) -> jstring {
-    let cache_dir: String = env.get_string(cache_dir_j).expect("Couldn't create rust string").into();
-    let domain: String = env.get_string(domain_j).expect("Couldn't create rust string").into();
-    let req = &Request{
-        method: "GET".to_string(),
-        url: format!("https://{}/index.html", domain),
-        headers: Default::default(),
-        body: None
-    };
-    let output = match req.send(&DirectoryCache{
+    let cache_dir: String = env
+        .get_string(cache_dir_j)
+        .expect("Couldn't create rust string")
+        .into();
+    let domain: String = env
+        .get_string(domain_j)
+        .expect("Couldn't create rust string")
+        .into();
+
+    let req = Request::get(format!("https://{}", domain))
+        .header("Host", domain)
+        .body(vec![])
+        .expect("create request");
+
+    let client = Client::new(DirectoryCache {
         tmp_dir: Some(cache_dir),
         nodes: None,
-        relays: None
-    }) {
-        Ok(s) => format!("Result is: {:?}", s),
+        relays: None,
+    });
+
+    let output = match client.send(req) {
+        Ok(s) => format!(
+            "Result is: {:?}",
+            s.map(|raw| String::from_utf8(raw).expect("decode body as utf8"))
+        ),
         Err(e) => format!("Error while getting result: {}", e),
     };
-    env.new_string(output).expect("Failed to build java string").into_inner()
+
+    env.new_string(output)
+        .expect("Failed to build java string")
+        .into_inner()
 }

--- a/src/ffi/android.rs
+++ b/src/ffi/android.rs
@@ -1,10 +1,10 @@
+use http::Request;
 use jni::objects::{JClass, JString};
 use jni::sys::jstring;
 use jni::JNIEnv;
-use log::info;
+use tracing::info;
 
 use crate::{client::Client, DirectoryCache};
-use http::Request;
 
 const ANDROID_LOG_TAG: &str = "ArtiLib";
 
@@ -34,7 +34,6 @@ pub unsafe extern "system" fn Java_org_c4dt_artiwrapper_JniApi_initLogger(_: JNI
     // This allows to process the messages arbitrarily in the app.
     android_logger::init_once(
         android_logger::Config::default()
-            .with_min_level(log::Level::Debug)
             .with_tag(ANDROID_LOG_TAG),
     );
     // Log panics rather than printing them.

--- a/src/ffi/ios.rs
+++ b/src/ffi/ios.rs
@@ -4,13 +4,19 @@ use core_foundation::{
 };
 use http::Request;
 use libc::c_char;
-use log::LevelFilter;
 
 use crate::{client::Client, DirectoryCache};
 
+fn setup_logger() {
+    let subscriber = tracing_fmt::FmtSubscriber::builder()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_writer(std::io::stderr)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("to be the only logger");
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn call_tls_get(domain_cc: *const c_char) -> CFStringRef {
-    simple_logging::log_to_stderr(LevelFilter::Debug);
     let domain = cstring_to_str(&domain_cc);
 
     let client = Client::new(DirectoryCache {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,56 +1,7 @@
-use anyhow::{Result, bail};
-use log::info;
-use std::collections::HashMap;
-use url::Url;
-
-use crate::arti::tls_send;
+pub mod client;
 
 mod arti;
 mod ffi;
-
-/// Request for the different REST methods. Here we don't differentiate between
-/// the url and the parameters passed to the remote end.
-/// Only http and https URLs are supported for the moment.
-pub struct Request {
-    pub method: String,
-    pub url: String,
-    pub headers: HashMap<String, String>,
-    pub body: Option<String>,
-}
-
-impl Request {
-    /// Sends the request to the given URL. It returns the response.
-    pub fn send(&self, dir_cache: &DirectoryCache) -> Result<Response> {
-        let request = &self.to_str()?;
-        info!("Contacting path {}", request);
-        let resp = tls_send(&self.host()?, request, dir_cache)?;
-        Ok(Response {
-            code: 100,
-            body: Some(resp),
-        })
-    }
-
-    /// Returns the string to be sent to the host.
-    fn to_str(&self) -> Result<String> {
-        info!("Sending GET request to {}", self.url);
-        let url = Url::parse(&self.url)?;
-        if url.scheme() != "https" {
-            bail!("Currently only supports https");
-        }
-        let host = &url.domain().unwrap();
-        // TODO: add other headers
-        // TODO: add body
-        // Needs to follow https://www.rfc-editor.org/rfc/rfc7230.html#page-19
-        Ok(format!("{} {} HTTP/1.0\r\nHost: {}\r\n\r\n",
-                   self.method, url.path(), host))
-    }
-
-    /// Returns the host, or an error if it's not defined.
-    fn host(&self) -> Result<String> {
-        let url = Url::parse(&self.url)?;
-        Ok(url.domain().unwrap().into())
-    }
-}
 
 /// The DirectoryCache allows arti to avoid having to download all the nodes and
 /// relays when starting up. This improves the request-time a lot, as arti now only
@@ -63,43 +14,4 @@ pub struct DirectoryCache {
     pub tmp_dir: Option<String>,
     pub nodes: Option<String>,
     pub relays: Option<String>,
-}
-
-
-/// Response from the REST call. If an error happened during the call,
-/// no Response will be sent.
-/// The 'code' is parsed from the response.
-#[derive(Debug)]
-pub struct Response {
-    pub code: i32,
-    pub body: Option<String>,
-}
-
-#[test]
-fn test_get() {
-    use log::LevelFilter;
-
-    simple_logging::log_to_stderr(LevelFilter::Debug);
-
-    let req = Request {
-        method: "GET".into(),
-        url: "https://www.c4dt.org/index.html".into(),
-        headers: HashMap::new(),
-        body: None,
-    };
-    match req.send(&DirectoryCache {
-        tmp_dir: None,
-        nodes: None,
-        relays: None,
-    }) {
-        Ok(resp) => {
-            info!("Sent GET to c4dt.org and got code {}", resp.code);
-            if let Some(body) = resp.body {
-                info!("Body is: {}", body);
-            }
-        }
-        Err(e) => {
-            panic!("Encountered error: {}", e);
-        }
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@ pub mod client;
 mod arti;
 mod ffi;
 
+#[cfg(test)]
+mod tests;
+
 /// The DirectoryCache allows arti to avoid having to download all the nodes and
 /// relays when starting up. This improves the request-time a lot, as arti now only
 /// needs to set up the circuit, and not download the information of all the nodes.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,6 @@
+pub fn setup_tracing() {
+    let subscriber = tracing_fmt::FmtSubscriber::builder()
+        .with_max_level(tracing::Level::DEBUG)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("to be the only logger");
+}


### PR DESCRIPTION
* drop custom implementation of Request & Response and use `http::{Request, Response}` directly
* have a dedicated `Client` taking care of the cache and can send Request & Response
* move that in a dedicated mod
* move to tracing for logging as to avoid concurrency issues with simple_logging
* use a dedicated cachedir for tests