### PR TITLE
tests: add log -> tracing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,7 @@
 name: Build
 on:
   pull_request:
+  push:
     branches:
       - main
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,7 @@
 name: Test
 on:
   pull_request:
+  push:
     branches:
       - main
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ dependencies = [
  "tor-rtcompat",
  "tracing",
  "tracing-fmt",
+ "tracing-log",
  "url",
  "webpki-roots",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "staticlib"]
 log-panics = "2.0"
 tracing = "0.1"
 tracing-fmt = "0.1"
+tracing-log = "0.1"
 
 # Packages for tor
 tor-client = { git = "https://gitlab.torproject.org/tpo/core/arti.git", rev = "c372671b5ad2663151cbaf2ff392f1e6f0ba292f" }

--- a/src/client.rs
+++ b/src/client.rs
@@ -102,6 +102,8 @@ mod tests {
 
     #[test]
     fn test_get() {
+        crate::tests::setup_tracing();
+
         let tempdir = TempDir::new("tor-cache").expect("create temp dir");
         let resp = Client::new(DirectoryCache {
             tmp_dir: tempdir.path().to_str().map(String::from),

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,6 +19,10 @@ impl Client {
     pub fn send(&self, req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>> {
         trace!("request: {:?}", req);
 
+        if req.version() != http::Version::HTTP_10 {
+            bail!("only supports HTTP version 1.0")
+        }
+
         let uri = req.uri().clone();
         let host = uri.host().context("no host found")?;
 
@@ -40,28 +44,37 @@ impl Client {
 }
 
 fn serialize_request(req: Request<Vec<u8>>) -> Result<Vec<u8>> {
+    const EOL: &str = "\n";
+
     let (parts, mut body) = req.into_parts();
 
     let mut ret = Vec::new();
 
     write!(
         &mut ret,
-        "{} {} {:?}\r\n",
-        parts.method, parts.uri, parts.version,
+        "{} {} {:?}{}",
+        parts.method,
+        parts
+            .uri
+            .path_and_query()
+            .context("uri without path or query")?,
+        parts.version,
+        EOL,
     )
     .context("write status line")?;
 
     for (key, value) in parts.headers {
         write!(
             &mut ret,
-            "{}: {}\r\n",
+            "{}: {}{}",
             key.context("missing header name")?,
             value.to_str().context("serialize header value as string")?,
+            EOL,
         )
         .context("write header")?;
     }
 
-    write!(&mut ret, "\r\n").context("write last EOL")?;
+    write!(&mut ret, "{}", EOL).context("write last EOL")?;
 
     ret.append(&mut body);
 
@@ -113,6 +126,7 @@ mod tests {
         .send(
             Request::get("https://www.c4dt.org")
                 .header("Host", "www.c4dt.org")
+                .version(http::Version::HTTP_10)
                 .body(vec![])
                 .expect("create get request"),
         )

--- a/src/ffi/android.rs
+++ b/src/ffi/android.rs
@@ -2,7 +2,7 @@ use http::Request;
 use jni::objects::{JClass, JString};
 use jni::sys::jstring;
 use jni::JNIEnv;
-use tracing::{log::Level, info};
+use tracing::{info, log::Level};
 
 use crate::{client::Client, DirectoryCache};
 
@@ -60,6 +60,7 @@ pub unsafe extern "system" fn Java_org_c4dt_artiwrapper_JniApi_tlsGet(
         .into();
 
     let req = Request::get(format!("https://{}", domain))
+        .version(http::Version::HTTP_10)
         .header("Host", domain)
         .body(vec![])
         .expect("create request");

--- a/src/ffi/ios.rs
+++ b/src/ffi/ios.rs
@@ -26,6 +26,7 @@ pub unsafe extern "C" fn call_tls_get(domain_cc: *const c_char) -> CFStringRef {
     });
 
     let req = Request::get(format!("https://{}", domain))
+        .version(http::Version::HTTP_10)
         .header("Host", domain)
         .body(vec![])
         .expect("construct request");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,8 +1,11 @@
 pub fn setup_tracing() {
-    let subscriber = tracing_fmt::FmtSubscriber::builder()
-        .with_max_level(tracing::Level::DEBUG)
-        .finish();
-    tracing::subscriber::set_global_default(subscriber).expect("to be the only logger");
+    // dropping error as many tests can setup_tracing
 
-    tracing_log::LogTracer::init().expect("to register tracing logger")
+    let _ = tracing::subscriber::set_global_default(
+        tracing_fmt::FmtSubscriber::builder()
+            .with_max_level(tracing::Level::DEBUG)
+            .finish(),
+    );
+
+    let _ = tracing_log::LogTracer::init();
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,4 +3,6 @@ pub fn setup_tracing() {
         .with_max_level(tracing::Level::DEBUG)
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("to be the only logger");
+
+    tracing_log::LogTracer::init().expect("to register tracing logger")
 }


### PR DESCRIPTION
`log` generated events doesn't show in `tracing` output. Adding a bridge to do that.