### PR TITLE
Use "log" feature of "tracing" to emit logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,6 @@ dependencies = [
  "httparse",
  "jni",
  "libc",
- "log",
  "log-panics",
  "openssl-sys",
  "ring",
@@ -2731,6 +2730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ url = "2.2.2"
 [target.'cfg(target_os="android")'.dependencies]
 jni = { version = "0.16", default-features = false }
 android_logger = "0.10.1"
-log = "0.4.6"
 openssl-sys = { version = "0.9.62", features = ["vendored"] }
 rusqlite = { version = "0.25.1", features = ["bundled"] }
+tracing = {version = "0.1", features = ["log"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
 libc = "0.2"

--- a/src/ffi/android.rs
+++ b/src/ffi/android.rs
@@ -2,8 +2,7 @@ use http::Request;
 use jni::objects::{JClass, JString};
 use jni::sys::jstring;
 use jni::JNIEnv;
-use log::Level;
-use log::info;
+use tracing::{log::Level, info};
 
 use crate::{client::Client, DirectoryCache};
 


### PR DESCRIPTION
Indeed, using the "log" feature of "tracing" seems to work :)

Here my intention is to enable that feature only for the Android build, hopefully this is the right syntax...