### PR TITLE
Fix db lock

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,10 +19,14 @@ jobs:
           ndk-version: r21e
           add-to-path: false
 
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: aarch64-linux-android
+
       - name: Add android to target
-        run: |
-          rustup target add aarch64-linux-android
-          cargo install cargo-ndk
+        run: cargo install cargo-ndk
 
       - name: Build android version
         run: |
@@ -47,8 +51,11 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
-      - name: Add ios to target
-        run: rustup target add x86_64-apple-ios
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: x86_64-apple-ios
 
       - name: Build ios version
         run: cargo build --target x86_64-apple-ios

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,18 +25,15 @@ jobs:
           toolchain: stable
           target: aarch64-linux-android
 
-      - name: Add android to target
-        run: cargo install cargo-ndk
+      - uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-ndk
 
-      - name: Build android version
-        run: |
-          # I have no idea why this is not picked up automatically...
-          mkdir $HOME/bin
-          ln -s $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar $HOME/bin/aarch64-linux-android-ar
-          ln -s $ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang $HOME/bin/aarch64-linux-android-clang
-          export PATH=$PATH:$HOME/bin:$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin
-          export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android30-clang
-          cargo build --target aarch64-linux-android
+      - uses: actions-rs/cargo@v1
+        with:
+          command: ndk
+          args: --target aarch64-linux-android build
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
 
@@ -57,5 +54,7 @@ jobs:
           toolchain: stable
           target: x86_64-apple-ios
 
-      - name: Build ios version
-        run: cargo build --target x86_64-apple-ios
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target x86_64-apple-ios

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,12 +13,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
-      - uses: nttld/setup-ndk@v1
-        id: setup-ndk
-        with:
-          ndk-version: r21e
-          add-to-path: false
-
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -34,8 +28,6 @@ jobs:
         with:
           command: ndk
           args: --target aarch64-linux-android build
-        env:
-          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
 
   build-ios:
     runs-on: macos-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,16 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.rustup
-            target
-          key: ${{ runner.os }}-build-android-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-android
+      - uses: Swatinem/rust-cache@v1
 
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
@@ -54,16 +45,7 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-build-ios-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-ios
-            ${{ runner.os }}-build-android
+      - uses: Swatinem/rust-cache@v1
 
       - name: Add ios to target
         run: rustup target add x86_64-apple-ios

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
       - uses: Swatinem/rust-cache@v1
 
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,15 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-build-android-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-android
+      - uses: Swatinem/rust-cache@v1
 
       - uses: actions-rs/cargo@v1
         name: cargo test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-android
 
-      - name: Run tests
-        # Else the arti-sqlite might fail on concurrent access to the database
-        run: cargo test -j 1
+      - uses: actions-rs/cargo@v1
+        name: cargo test
+        with:
+          command: test


### PR DESCRIPTION
PR to find out more about this "db lock" issue.

It seems that when loading the ArtiConfig, the same cache path was used, so getting rid of it and using the parametrized cache path fixes it.

I also added some improvements on the github hooks, hopefully accelerating and simplifying it