### PR TITLE
client: handle multiple headers with same key

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -63,7 +63,7 @@ fn serialize_request(req: Request<Vec<u8>>) -> Result<Vec<u8>> {
     )
     .context("write status line")?;
 
-    for (key, value) in parts.headers.iter() {
+    for (key, value) in &parts.headers {
         write!(
             &mut ret,
             "{}: {}{}",

--- a/src/client.rs
+++ b/src/client.rs
@@ -63,11 +63,11 @@ fn serialize_request(req: Request<Vec<u8>>) -> Result<Vec<u8>> {
     )
     .context("write status line")?;
 
-    for (key, value) in parts.headers {
+    for (key, value) in parts.headers.iter() {
         write!(
             &mut ret,
             "{}: {}{}",
-            key.context("missing header name")?,
+            key,
             value.to_str().context("serialize header value as string")?,
             EOL,
         )


### PR DESCRIPTION
When sending a request containing multiple headers with the same key, I get an error while "serializing request". Digging deeper, it seems that the default iterator, instead of being the [one](https://docs.rs/http/0.2.4/http/header/struct.Iter.html) that would behave as:

> The same header name may be yielded more than once if it has more than one associated value.

produces instead a `None` name when the second value is provided (perhaps a Drain iterator?).

This fixes it, but there might be a more rusty way. :)