### PR TITLE
Adding arti-rest call for iOS ffi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "openssl-sys",
  "rusqlite",
  "serde 1.0.126",
+ "serde_json",
  "tempdir",
  "tokio",
  "tokio-native-tls",
@@ -133,6 +134,8 @@ dependencies = [
  "tracing",
  "tracing-fmt",
  "tracing-log",
+ "url",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -240,6 +243,12 @@ name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "bumpalo"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byteorder"
@@ -529,6 +538,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +772,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +824,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -899,6 +938,12 @@ checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "maybe-uninit"
@@ -1182,6 +1227,12 @@ dependencies = [
  "once_cell",
  "regex",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "phf"
@@ -1480,6 +1531,21 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
  "winapi",
 ]
 
@@ -1845,6 +1911,21 @@ dependencies = [
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
@@ -2313,10 +2394,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "vcpkg"
@@ -2354,10 +2471,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+
+[[package]]
 name = "weak-table"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8f3bf74f2d43500dea6a8291b6ac943e3465ea9936b94bd017e61b7b21dd01"
+
+[[package]]
+name = "web-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-fmt = "0.1"
 tracing-log = "0.1"
-url = "2.2.2"
 webpki-roots = "0.21"
 
 [dev-dependencies]
@@ -53,6 +52,7 @@ rusqlite = { version = "0.25.1", features = ["bundled"] }
 [target.'cfg(target_os = "ios")'.dependencies]
 core-foundation = "0.9"
 libc = "0.2"
+url = "2.2.2"
 
 [profile.release]
 opt-level = "s" # reduce library size

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,13 @@ log = "0.4"
 log-panics = "2"
 serde = { version = "1", features = ["derive"] }
 tokio-native-tls = "0.3"
+serde_json = "1.0.64"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-fmt = "0.1"
 tracing-log = "0.1"
+url = "2.2.2"
+webpki-roots = "0.21"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-fmt = "0.1"
 tracing-log = "0.1"
-webpki-roots = "0.21"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ $(arxcz): ios/$(arxc)
 
 dev:
 	perl -pi -e 's/lto = "fat"/lto = "thin"/' Cargo.toml
-	perl -pi -e 's/opt-level = "s"/#opt-level = "s"/' Cargo.toml
+	perl -pi -e 's/.*opt-level = "s"/#opt-level = "s"/' Cargo.toml
 	cd ios && \
 	./build_xcf.sh dev && \
 	cp -av arti-rest.xcframework ../../arti-ios

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,21 @@ arxc := arti-rest.xcframework
 arxcz := $(arxc).zip
 
 .PHONY: build-ios
-build-ios: ios/arti-rest.xcframework $(arxcz)
+build-ios: $(arxcz)
 
-ios/$(arxc): $(wildcard src/*)
+ios/$(arxc): $(wildcard src/*) ios/arti-rest.h ios/build_xcf.sh
 	( cd ios; ./build_xcf.sh )
 
 $(arxcz): ios/$(arxc)
 	cd ios && \
 	zip -r ../$(arxcz) $(arxc) && \
 	swift package compute-checksum ../$(arxcz)
+
+dev:
+	perl -pi -e 's/lto = "fat"/lto = "thin"/' Cargo.toml
+	perl -pi -e 's/opt-level = "s"/#opt-level = "s"/' Cargo.toml
+	cd ios && \
+	./build_xcf.sh dev && \
+	cp -av arti-rest.xcframework ../../arti-ios
+	perl -pi -e 's/lto = "thin"/lto = "fat"/' Cargo.toml
+	perl -pi -e 's/#opt-level = "s"/opt-level = "s"/' Cargo.toml

--- a/ios/arti-rest.h
+++ b/ios/arti-rest.h
@@ -5,4 +5,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-CFStringRef call_tls_get(const char *domain);
+/**
+ * The call to arti
+ */
+CFStringRef call_arti(const char *request);

--- a/ios/build_xcf.sh
+++ b/ios/build_xcf.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # This should theoretically also work with 'debug' and be much faster for
 # testing.
 # However, the creation of the xcframework fails, according to
@@ -12,7 +14,12 @@ if [ "$MODE" = "release" ]; then
 fi
 
 XCFRAMEWORK_ARGS=""
-for arch in x86_64-apple-ios aarch64-apple-ios; do
+ARCHS="x86_64-apple-ios aarch64-apple-ios"
+if [ "$1" = dev ]; then
+  ARCHS=x86_64-apple-ios
+fi
+
+for arch in $ARCHS; do
 	cargo build --target $arch $MODEFLAG
 	tdir=../target/$arch/$MODE
   mkdir -p $tdir/headers

--- a/src/arti.rs
+++ b/src/arti.rs
@@ -44,7 +44,7 @@ pub fn tls_send(host: &str, request: &str, cache: &Path) -> Result<String> {
 async fn send_request(tor: TorClient<impl Runtime>, host: &str, request: &str) -> Result<String> {
     debug!(host, "send request");
 
-    for retry in 0..2u32 {
+    for retry in 0..5u32 {
         debug!(retry, "trying to connect");
         let stream: conv::TorStream = tor
             .connect(host, 443, None)

--- a/src/arti.rs
+++ b/src/arti.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Context, Result};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_native_tls::{native_tls, TlsConnector};
 use tor_rtcompat::{Runtime, SpawnBlocking};
-use tracing::{debug, info, trace};
+use tracing::{debug, trace};
 
 use crate::arti::client::TorClient;
 
@@ -45,7 +45,7 @@ async fn send_request(tor: TorClient<impl Runtime>, host: &str, request: &str) -
     debug!(host, "send request");
 
     for retry in 0..5u32 {
-        debug!(retry, "trying to connect");
+        debug!("Connection-try {}", retry);
         let stream: conv::TorStream = tor
             .connect(host, 443, None)
             .await
@@ -71,7 +71,6 @@ async fn send_request(tor: TorClient<impl Runtime>, host: &str, request: &str) -
             trace!("Received stream: {}", result);
             return Ok(result);
         }
-        info!("Trying again");
     }
 
     Err(anyhow!("Couldn't get response"))

--- a/src/ffi/ios.rs
+++ b/src/ffi/ios.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use core_foundation::{
@@ -24,50 +25,73 @@ struct ArtiRequest {
     dict_dir: String,
 }
 
+impl TryFrom<ArtiRequest> for http::Request<Vec<u8>> {
+    type Error = anyhow::Error;
+
+    fn try_from(request: ArtiRequest) -> Result<Self, Self::Error> {
+        let host_url = Url::parse(&request.url).context("parse url")?;
+        let host = host_url.host_str().context("no host in request")?;
+
+        let mut req = Request::builder()
+            .method(Method::from_bytes(request.method.as_bytes()).context("invalid method")?)
+            .header("Host", host)
+            .version(http::Version::HTTP_10)
+            .uri(&request.url)
+            .body(request.body)
+            .context("invalid request")?;
+
+        let hm = req.headers_mut();
+        for (key, values) in request.headers {
+            for value in values {
+                hm.append(
+                    &HeaderName::from_bytes(&key.as_bytes())?,
+                    HeaderValue::from_bytes(value.as_bytes())?,
+                );
+            }
+        }
+
+        Ok(req)
+    }
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn call_arti(request_json: *const c_char) -> CFStringRef {
     setup_logger();
 
-    let ret = _call_arti(cstring_to_str(&request_json)).unwrap_or_else(|e| ReturnStruct {
-        error: Some(JSONError {
-            error_string: e.to_string(),
-            error_context: None,
-        }),
-        response: None,
-    });
+    let ret = _call_arti(cstring_to_str(&request_json))
+        .map(|resp| ReturnStruct {
+            response: Some(resp),
+            error: None,
+        })
+        .unwrap_or_else(|e| ReturnStruct {
+            error: Some(JSONError {
+                error_string: e.to_string(),
+                error_context: None,
+            }),
+            response: None,
+        });
 
-    let json_str = serde_json::to_string(&ret).unwrap_or("JSON error".into());
-    return to_cf_str(json_str.to_string());
+    // FIXME doesn't yield valid response on JSON error
+    to_cf_str(serde_json::to_string(&ret).unwrap_or("JSON error".into()))
 }
 
-fn _call_arti(request_json: &str) -> Result<ReturnStruct> {
-    let request: ArtiRequest = serde_json::from_str(request_json)?;
+fn _call_arti(request_json: &str) -> Result<Response> {
+    let request: ArtiRequest =
+        serde_json::from_str(request_json).context("parse request as JSON")?;
     info!("JSON-Request is: {:?}", request);
 
-    let host_url = Url::parse(&request.url).context("parse url")?;
-    let host = host_url.host_str().context("no host in request")?;
+    // TODO avoid binding field to struct to avoid copying around
+    let cache_dir = PathBuf::from(request.dict_dir.clone());
 
-    let mut req = Request::builder()
-        .method(Method::from_bytes(request.method.as_bytes()).context("invalid method")?)
-        .header("Host", host)
-        .version(http::Version::HTTP_10)
-        .uri(&request.url)
-        .body(request.body)
-        .context("invalid request")?;
-
-    let hm = req.headers_mut();
-    for (key, values) in request.headers {
-        for value in values {
-            hm.append(
-                &HeaderName::from_bytes(&key.as_bytes())?,
-                HeaderValue::from_bytes(value.as_bytes())?,
-            );
-        }
-    }
-
+    let req = request
+        .try_into()
+        .context("convert request to http::Request")?;
     info!("Parsed request is: {:?}", req);
 
-    Client::new(request.dict_dir.into()).send(req).try_into()
+    let resp = Client::new(cache_dir).send(req).context("send request")?;
+
+    resp.try_into()
+        .context("convert http::Response to response")
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -83,53 +107,47 @@ struct Response {
     body: Vec<u8>,
 }
 
+impl TryFrom<http::response::Response<Vec<u8>>> for Response {
+    type Error = anyhow::Error;
+
+    fn try_from(resp: http::response::Response<Vec<u8>>) -> Result<Self, Self::Error> {
+        let mut headers = HashMap::new();
+        for (k, v) in resp.headers() {
+            headers.insert(k.to_string(), vec![v.to_str()?.to_string()]);
+        }
+
+        Ok(Response {
+            status: resp.status().as_u16(),
+            headers,
+            body: resp.body().clone(),
+        })
+    }
+}
+
+// TODO rename as it isn't only a JSON only error
 #[derive(Serialize, Deserialize, Debug)]
 struct JSONError {
     error_string: String,
+    // TODO remove, it is not possible to extract context with `anyhow`
     error_context: Option<String>,
-}
-
-impl TryFrom<Result<http::response::Response<Vec<u8>>>> for ReturnStruct {
-    type Error = anyhow::Error;
-
-    fn try_from(
-        resp_result: Result<http::response::Response<Vec<u8>>>,
-    ) -> Result<Self, anyhow::Error> {
-        match resp_result {
-            Ok(resp) => {
-                let mut headers = HashMap::new();
-                for (k, v) in resp.headers() {
-                    headers.insert(k.to_string(), vec![v.to_str()?.to_string()]);
-                }
-                Ok(Self {
-                    error: None,
-                    response: Some(Response {
-                        status: resp.status().as_u16(),
-                        headers,
-                        body: resp.body().clone(),
-                    }),
-                })
-            }
-            Err(e) => Err(e),
-        }
-    }
 }
 
 fn to_cf_str(str: String) -> CFStringRef {
     let cf_string = CFString::new(&str);
     let cf_string_ref = cf_string.as_concrete_TypeRef();
-    ::std::mem::forget(cf_string);
+    ::std::mem::forget(cf_string); // FIXME seems really weird to be needing this
     cf_string_ref
 }
 
 // Convert C string to Rust string slice
 unsafe fn cstring_to_str<'a>(cstring: &'a *const c_char) -> &str {
     if cstring.is_null() {
-        // Of course in a real project you'd return Result instead
+        // TODO Of course in a real project you'd return Result instead
         panic!("cstring is null")
     }
 
     let raw = ::std::ffi::CStr::from_ptr(*cstring);
+    // TODO panic not handled
     raw.to_str().expect("Couldn't convert c string to slice")
 }
 

--- a/src/ffi/ios.rs
+++ b/src/ffi/ios.rs
@@ -16,7 +16,7 @@ use url::Url;
 use crate::client::Client;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct ArtiRequest {
+struct ArtiRequest {
     method: String,
     url: String,
     headers: HashMap<String, Vec<String>>,
@@ -40,7 +40,7 @@ pub unsafe extern "C" fn call_arti(request_json: *const c_char) -> CFStringRef {
     return to_cf_str(json_str.to_string());
 }
 
-pub fn _call_arti(request_json: &str) -> Result<ReturnStruct> {
+fn _call_arti(request_json: &str) -> Result<ReturnStruct> {
     let request: ArtiRequest = serde_json::from_str(request_json)?;
     info!("JSON-Request is: {:?}", request);
 
@@ -71,20 +71,20 @@ pub fn _call_arti(request_json: &str) -> Result<ReturnStruct> {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct ReturnStruct {
+struct ReturnStruct {
     error: Option<JSONError>,
     response: Option<Response>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Response {
+struct Response {
     status: u16,
     headers: HashMap<String, Vec<String>>,
     body: Vec<u8>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct JSONError {
+struct JSONError {
     error_string: String,
     error_context: Option<String>,
 }


### PR DESCRIPTION
The rest-part of the ios-library for arti-rest. The argument-passing between ios and rest is done using a JSON string that is parsed on both ends.

See also #28