### PR TITLE
Propagate errors instead of panics

### DIFF
--- a/src/arti/conv.rs
+++ b/src/arti/conv.rs
@@ -48,7 +48,10 @@ impl tokio::io::AsyncWrite for TorStream {
         use futures::{io::AsyncWrite, ready};
         let ret = Pin::new(&mut self.wrapped).poll_write(cx, buf);
         // FIXME dirty fix to force tls->tor communication
-        ready!(self.poll_flush(cx)).unwrap();
+        match ready!(self.poll_flush(cx)) {
+            Err(e) => return Poll::Ready(Err(e)),
+            _ => (),
+        }
         ret
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,7 @@ use std::{io::Write, path::PathBuf};
 
 use anyhow::{bail, Context, Result};
 use http::{Request, Response};
+use std::panic;
 use tracing::trace;
 
 use crate::arti::tls_send;
@@ -28,13 +29,16 @@ impl Client {
 
         let raw_req = serialize_request(req).context("serialize request")?;
 
-        let raw_resp = tls_send(
-            host,
-            &String::from_utf8(raw_req).context("encode serialized as utf-8")?,
-            &self.cache,
-        )
-        .context("tls send")?
-        .into_bytes();
+        let raw_resp = match panic::catch_unwind(|| {
+            tls_send(
+                host,
+                &String::from_utf8(raw_req).context("encode serialized as utf-8")?,
+                &self.cache,
+            )
+        }) {
+            Ok(v) => v.context("tls send")?.into_bytes(),
+            Err(e) => bail!("caught panic: {:?}", e),
+        };
 
         let resp = deserialize_response(raw_resp);
 


### PR DESCRIPTION
See #47 

Replace some `unwrap()` or `expect()` calls with error propagation or `anyhow::context()`.

This fixes the main ones I could find. Some others remain, in the following categories:
- Cannot be triggered AFAIU, e.g.:
  - https://github.com/c4dt/arti-rest/blob/main/src/client.rs#L109 (will panic on partial response, but this is handled before in https://github.com/c4dt/arti-rest/blob/main/src/client.rs#L94-L96)
  - https://github.com/c4dt/arti-rest/blob/main/src/arti/tor-dirmgr/src/state.rs#L209 (will panic on `None`, but explicitely assigned to `Some(...)` in https://github.com/c4dt/arti-rest/blob/main/src/arti/tor-dirmgr/src/state.rs#L199-L207)
- Tests
- Deeply rooted into Arti code (e.g. `shared_ref.rs`, `config.rs`) and might require some more time to address, besides possibly conflicting with Arti's code evolution in //.

Should I work on these last ones?