### PR TITLE
Put arti-rest headers for ios in separate subdirectory

### DIFF
--- a/.github/workflows/ios-release.yaml
+++ b/.github/workflows/ios-release.yaml
@@ -16,8 +16,6 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: Swatinem/rust-cache@v1
-
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -29,6 +27,8 @@ jobs:
           profile: minimal
           toolchain: stable
           target: aarch64-apple-ios
+
+      - uses: Swatinem/rust-cache@v1
 
       - name: Build XCFramework
         run: |

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,9 @@ $(arxcz): ios/$(arxc)
 dev:
 	perl -pi -e 's/lto = "fat"/lto = "thin"/' Cargo.toml
 	perl -pi -e 's/.*opt-level = "s"/#opt-level = "s"/' Cargo.toml
+	rm -rf ../arti-ios/arti-rest.xcframework
 	cd ios && \
 	./build_xcf.sh dev && \
 	cp -av arti-rest.xcframework ../../arti-ios
 	perl -pi -e 's/lto = "thin"/lto = "fat"/' Cargo.toml
-	perl -pi -e 's/#opt-level = "s"/opt-level = "s"/' Cargo.toml
+	perl -pi -e 's/.*#opt-level = "s"/opt-level = "s"/' Cargo.toml

--- a/ios/build_xcf.sh
+++ b/ios/build_xcf.sh
@@ -20,12 +20,14 @@ if [ "$1" = dev ]; then
 fi
 
 for arch in $ARCHS; do
-	cargo build --target $arch $MODEFLAG
-	tdir=../target/$arch/$MODE
-  mkdir -p $tdir/headers
-	cp arti-rest.h module.modulemap $tdir/headers
+  cargo build --target $arch $MODEFLAG
+  tdir=../target/$arch/$MODE
+  hdir=$tdir/arti-rest
+  rm -rf $hdir
+  mkdir -p $hdir
+  cp arti-rest.h module.modulemap $hdir
   XCFRAMEWORK_ARGS="${XCFRAMEWORK_ARGS} -library $tdir/libcore.a"
-  XCFRAMEWORK_ARGS="${XCFRAMEWORK_ARGS} -headers $tdir/headers/"
+  XCFRAMEWORK_ARGS="${XCFRAMEWORK_ARGS} -headers $hdir"
 done
 
 XCFFILE=arti-rest.xcframework


### PR DESCRIPTION
Because XCode copies all headers from all Swift Packages into one single
directory, the headers must be unique. So using a name like `Headers`
will most probably collide.

This PR uses a different name for the header directory.

Closes #58