### PR TITLE
Remove arti-ios trigger

### DIFF
--- a/.github/workflows/ios-release.yaml
+++ b/.github/workflows/ios-release.yaml
@@ -40,12 +40,3 @@ jobs:
           artifacts: "arti-rest.xcframework.zip"
           bodyFile: "ios/body.md"
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: trigger
-        run: |
-          curl \
-            -u ${{ secrets.REPO_TOKEN_USER }}:${{ secrets.REPO_TOKEN }} \
-            -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/c4dt/arti-ios/dispatches \
-            -d '{"event_type":"update"}'

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The patch version of the three will differ and reflect internal updates, with th
 following constraints:
 - `patch_version(arti_android) >= patch_version(arti_rest)`
 - `patch_version(arti_ios) >= patch_version(arti_rest)`
-- a new arti-rest patch version must be bigger than both the arti-android and
+- a new arti-rest patch version must be bigger than both the current arti-android and
 arti-ios patch version
 
 This allows us to quickly verify that a given library version has at least some patches

--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ For the iOS test app, see here:
 - v0.4 - Configure arti-rest to either use standard tor, or a pre-configured circuit
 - v1.0 - Once arti is deemed stable enough, and other people have looked and used this code
 
+### Versioning
+
+The following repos follow the same versioning related to the major and minor version:
+- arti-rest
+- arti-android
+- arti-ios
+
+The patch version of the three will differ and reflect internal updates, with the
+following constraints:
+- `patch_version(arti_android) >= patch_version(arti_rest)`
+- `patch_version(arti_ios) >= patch_version(arti_rest)`
+- a new arti-rest patch version must be bigger than both the arti-android and
+arti-ios patch version
+
+This allows us to quickly verify that a given library version has at least some patches
+from the arti-rest code by simply looking at the version number.
+
 ## Directories
 
 - `./` is the rust library for the wrapper with arti


### PR DESCRIPTION
As the version numbering will be differing according to the README,
the automatic trigger to create a new arti-ios doesn't make sense anymore.