### PR TITLE
Add target to create base64 output for arti-directory

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -29,3 +29,9 @@ check-password:
 ifeq ($(DIR_AUTH_PASSWORD), )
 	$(error Environment variable DIR_AUTH_PASSWORD is undefined or invalid.)
 endif
+
+secrets_authority: $(AUTH_DIR)
+	tar cjf auth.tgz $(AUTH_DIR) $(DIR_CACHE)/{certificate.txt,authority.txt}
+	base64 -i auth.tgz
+	rm auth.tgz
+	echo $$DIR_AUTH_PASSWORD


### PR DESCRIPTION
The arti-directory repository creates a new set of nodes every day, but it needs
the certificate of the authority. Now you can create these with

```
make secrets_authority
```

Depends on #62 

Tested and works on:
- [x] iOS - @ineiti 
- [x] Android - @cgrigis 